### PR TITLE
Fix TimelineSegmentGetter

### DIFF
--- a/src/dash/utils/SegmentsUtils.js
+++ b/src/dash/utils/SegmentsUtils.js
@@ -222,33 +222,6 @@ export function getSegmentByIndex(index, representation) {
     return null;
 }
 
-
-export function decideSegmentListRangeForTimeline(timelineConverter, isDynamic, requestedTime, index, givenAvailabilityUpperLimit) {
-    var availabilityLowerLimit = 2;
-    var availabilityUpperLimit = givenAvailabilityUpperLimit || 10;
-    var firstIdx = 0;
-    var lastIdx = Number.POSITIVE_INFINITY;
-
-    var start,
-        end,
-        range;
-
-    if (isDynamic && !timelineConverter.isTimeSyncCompleted()) {
-        range = {start: firstIdx, end: lastIdx};
-        return range;
-    }
-
-    if ((!isDynamic && requestedTime) || index < 0) return null;
-
-    // segment list should not be out of the availability window range
-    start = Math.max(index - availabilityLowerLimit, firstIdx);
-    end = Math.min(index + availabilityUpperLimit, lastIdx);
-
-    range = {start: start, end: end};
-
-    return range;
-}
-
 export function decideSegmentListRangeForTemplate(timelineConverter, isDynamic, representation, requestedTime, index, givenAvailabilityUpperLimit) {
     var duration = representation.segmentDuration;
     var minBufferTime = representation.adaptation.period.mpd.manifest.minBufferTime;
@@ -303,5 +276,3 @@ export function decideSegmentListRangeForTemplate(timelineConverter, isDynamic, 
 
     return range;
 }
-
-

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -31,7 +31,7 @@
 
 import FactoryMaker from '../../core/FactoryMaker';
 
-import {getTimeBasedSegment, decideSegmentListRangeForTimeline} from './SegmentsUtils';
+import {getTimeBasedSegment} from './SegmentsUtils';
 
 function TimelineSegmentsGetter(config, isDynamic) {
 

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -39,7 +39,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
 
     let instance;
 
-    function getSegmentsFromTimeline(representation, requestedTime, index, availabilityUpperLimit = Infinity) {
+    function getSegmentsFromTimeline(representation, requestedTime = null, index, availabilityUpperLimit) {
         var base = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].
             AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].SegmentTemplate ||
             representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].
@@ -65,7 +65,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
             nextFrag,
             calculatedRange,
             hasEnoughSegments,
-            requiredMediaTime,
+            requiredMediaTime = null,
             startIdx,
             endIdx,
             fTimescale;
@@ -98,7 +98,9 @@ function TimelineSegmentsGetter(config, isDynamic) {
         startIdx = index;
         endIdx = index + availabilityUpperLimit;
 
-        requiredMediaTime = timelineConverter.calcMediaTimeFromPresentationTime(requestedTime || 0, representation);
+        if (requestedTime !== null) {
+            requiredMediaTime = timelineConverter.calcMediaTimeFromPresentationTime(requestedTime, representation);
+        }
 
         for (i = 0, len = fragments.length; i < len; i++) {
             frag = fragments[i];

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -55,7 +55,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
 
         let maxSegmentsAhead;
         if (availabilityUpperLimit) {
-            maxSegmentsAhead = availabilityUpperLimit
+            maxSegmentsAhead = availabilityUpperLimit;
         } else {
             maxSegmentsAhead = (index > -1 || requestedTime !== null) ? 10 : Infinity;
         }
@@ -64,7 +64,6 @@ function TimelineSegmentsGetter(config, isDynamic) {
         var scaledTime = 0;
         var availabilityIdx = -1;
         var segments = [];
-        var isStartSegmentForRequestedTimeFound = false;
 
         var fragments,
             frag,
@@ -74,11 +73,9 @@ function TimelineSegmentsGetter(config, isDynamic) {
             repeat,
             repeatEndTime,
             nextFrag,
-            calculatedRange,
             hasEnoughSegments,
             requiredMediaTime = null,
             startIdx,
-            endIdx,
             fTimescale;
 
         var createSegment = function (s, i) {

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -166,23 +166,6 @@ function TimelineSegmentsGetter(config, isDynamic) {
                         segments.push(createSegment(frag, availabilityIdx));
                 }
 
-                /*
-
-                TODO: what do we do with that?
-
-                // In some cases when requiredMediaTime = actual end time of the last segment
-                // it is possible that this time a bit exceeds the declared end time of the last segment.
-                // in this case we still need to include the last segment in the segment list. to do this we
-                // use a correction factor = 1.5. This number is used because the largest possible deviation is
-                // is 50% of segment duration.
-                if (isStartSegmentForRequestedTimeFound) {
-                    segments.push(createSegment(frag, availabilityIdx));
-                }  else if (scaledTime >= (requiredMediaTime - (frag.d / fTimescale) * 1.5)) {
-                    isStartSegmentForRequestedTimeFound = true;
-                    segments.push(createSegment(frag, availabilityIdx));
-                }
-                */
-
                 time += frag.d;
                 scaledTime = time / fTimescale;
             }

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -64,6 +64,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
         var scaledTime = 0;
         var availabilityIdx = -1;
         var segments = [];
+        var requiredMediaTime = null;
 
         var fragments,
             frag,
@@ -74,7 +75,6 @@ function TimelineSegmentsGetter(config, isDynamic) {
             repeatEndTime,
             nextFrag,
             hasEnoughSegments,
-            requiredMediaTime = null,
             startIdx,
             fTimescale;
 
@@ -165,7 +165,7 @@ function TimelineSegmentsGetter(config, isDynamic) {
                         segments.push(createSegment(frag, availabilityIdx));
                     }
                 } else if (availabilityIdx >= startIdx) {
-                        segments.push(createSegment(frag, availabilityIdx));
+                    segments.push(createSegment(frag, availabilityIdx));
                 }
 
                 time += frag.d;

--- a/src/dash/utils/TimelineSegmentsGetter.js
+++ b/src/dash/utils/TimelineSegmentsGetter.js
@@ -39,7 +39,12 @@ function TimelineSegmentsGetter(config, isDynamic) {
 
     let instance;
 
-    function getSegmentsFromTimeline(representation, requestedTime = null, index, availabilityUpperLimit) {
+    function getSegmentsFromTimeline(representation, requestedTime, index, availabilityUpperLimit) {
+
+        if (requestedTime === undefined) {
+            requestedTime = null;
+        }
+
         var base = representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].
             AdaptationSet_asArray[representation.adaptation.index].Representation_asArray[representation.index].SegmentTemplate ||
             representation.adaptation.period.mpd.manifest.Period_asArray[representation.adaptation.period.index].


### PR DESCRIPTION
- simplify TimelineSegmentGetter logic
- Configurable maxSegmentAhead. ALways return full list of segment when index === -1 and requestedTime isn't specified
- Use time based segment search when available, and fall back on index based when it's not